### PR TITLE
adding templateProvider support

### DIFF
--- a/angular-ui-router-uib-modal.js
+++ b/angular-ui-router-uib-modal.js
@@ -45,14 +45,28 @@ angular.module("ui.router.modal", ["ui.router"])
 						}
 					}
 
-					var thisModal = openModal = $uibModal.open(options);
+					var openModalFunc = function () {
+						var thisModal = openModal = $uibModal.open(options);
 
-					openModal.result['finally'](function() {
-						if (thisModal === openModal) {
-							// Dialog was closed via $uibModalInstance.close/dismiss, go to our parent state
-							$state.go($state.get("^", stateName).name);
-						}
-					});
+						openModal.result['finally'](function() {
+							if (thisModal === openModal) {
+								// Dialog was closed via $uibModalInstance.close/dismiss, go to our parent state
+								$state.go($state.get("^", stateName).name);
+							}
+						});
+
+					}
+
+
+					if (options.templateProvider) {
+						options.templateProvider().then(function (template) {
+							options.template = template;
+							openModalFunc();
+						})
+					}
+					else {
+						openModalFunc();
+					}
 				};
 
 				// Make sure that onEnter receives state.resolve configuration

--- a/src/angular-ui-router-uib-modal.js
+++ b/src/angular-ui-router-uib-modal.js
@@ -33,14 +33,28 @@ angular.module("ui.router.modal", ["ui.router"])
 						}
 					}
 
-					var thisModal = openModal = $uibModal.open(options);
+					var openModalFunc = function () {
+						var thisModal = openModal = $uibModal.open(options);
 
-					openModal.result['finally'](function() {
-						if (thisModal === openModal) {
-							// Dialog was closed via $uibModalInstance.close/dismiss, go to our parent state
-							$state.go($state.get("^", stateName).name);
-						}
-					});
+						openModal.result['finally'](function() {
+							if (thisModal === openModal) {
+								// Dialog was closed via $uibModalInstance.close/dismiss, go to our parent state
+								$state.go($state.get("^", stateName).name);
+							}
+						});
+
+					}
+
+
+					if (options.templateProvider) {
+						options.templateProvider().then(function (template) {
+							options.template = template;
+							openModalFunc();
+						})
+					}
+					else {
+						openModalFunc();
+					}
 				};
 
 				// Make sure that onEnter receives state.resolve configuration


### PR DESCRIPTION
Template Providers are allowed on normal ui states but not in modal dialogs. This fix adds support for template providers to be used in the modal dialog which can help reduce file size for lazy loading.
